### PR TITLE
Fix: 1ページ目でnextのリンクがはられていないのを修正,  Add: config

### DIFF
--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -5,7 +5,4 @@
     total_pages  : total number of pages
     per_page     : number of items to fetch per page
     remote       : data-remote
-== link_to_unless current_page.first?, t('views.pagination.next').html_safe, url, :rel => 'next', :remote => remote, class: 'uk-slidenav uk-slidenav-contrast uk-slidenav-next',  'data-uk-slideshow-item' => 'next'
-'
-coffee:
-  $('.uk-slidenav-next').text('')
+== link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, :rel => 'next', :remote => remote, class: 'uk-slidenav uk-slidenav-contrast uk-slidenav-next',  'data-uk-slideshow-item' => 'next'

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -6,6 +6,3 @@
     per_page     : number of items to fetch per page
     remote       : data-remote
 == link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, :rel => 'prev', :remote => remote, class: 'uk-slidenav uk-slidenav-contrast uk-slidenav-previous',  'data-uk-slideshow-item' => 'previous'
-'
-coffee:
-  $('.uk-slidenav-previous').text('')

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,10 @@
+Kaminari.configure do |config|
+  config.default_per_page = 1
+  config.max_per_page = nil
+  config.window = 4
+  config.outer_window = 0
+  config.left  = 0
+  config.right = 0
+  config.page_method_name = :page
+  config.param_name = :page
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -193,3 +193,9 @@ ja:
       long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       short: "%y/%m/%d %H:%M"
     pm: 午後
+  views:
+    pagination:
+      first: "First"
+      last:  "Last"
+      next: ""
+      previous: ""


### PR DESCRIPTION
- link_to_unless の条件式を間違っていたため1ページ目のnextボタンが消えていた．
- jsで文字を上書きして消していたのを，config/locales/ja.ymlに言語設定を追記して消す形に
- config/initializers/kaminari_config.rb の追加
